### PR TITLE
Pad output bytes, double rx ring buffer size

### DIFF
--- a/components/fujitsu_heat_pump/FujiHeatPump.cpp
+++ b/components/fujitsu_heat_pump/FujiHeatPump.cpp
@@ -264,8 +264,8 @@ void FujiHeatPump::connect(uart_port_t uart_port, bool secondary, int rxPin, int
 }
 
 void FujiHeatPump::printFrame(byte buf[kFrameSize], FujiFrame ff) {
-    ESP_LOGD(TAG, "%X %X %X %X %X %X %X %X  ", buf[0], buf[1], buf[2],
-             buf[3], buf[4], buf[5], buf[6], buf[7]);
+    ESP_LOGD(TAG, "%02hhX %02hhX %02hhX %02hhX %02hhX %02hhX %02hhX %02hhX",
+        buf[0], buf[1], buf[2], buf[3], buf[4], buf[5], buf[6], buf[7]);
     ESP_LOGD(
         TAG,
         " mSrc: %d mDst: %d mType: %d write: %d login: %d unknown: %d onOff: "

--- a/components/fujitsu_heat_pump/FujiHeatPump.cpp
+++ b/components/fujitsu_heat_pump/FujiHeatPump.cpp
@@ -215,7 +215,7 @@ void FujiHeatPump::connect(uart_port_t uart_port, bool secondary, int rxPin, int
             return;
         }
     }
-    rc = uart_driver_install(uart_port, 2048, 2048, 20, &this->uart_queue, 0);
+    rc = uart_driver_install(uart_port, 4096, 2048, 20, &this->uart_queue, 0);
     if (rc != 0) {
         ESP_LOGW(TAG, "Failed to install uart driver");
         return;

--- a/components/fujitsu_heat_pump/FujiHeatPump.h
+++ b/components/fujitsu_heat_pump/FujiHeatPump.h
@@ -12,6 +12,8 @@ typedef uint8_t byte;
 namespace esphome {
 namespace fujitsu {
 
+const size_t kFrameSize = 8;
+
 const byte kModeIndex = 3;
 const byte kModeMask = 0b00001110;
 const byte kModeOffset = 1;
@@ -81,7 +83,7 @@ typedef struct FujiFrames {
 
 class FujiHeatPump {
    private:
-    byte readBuf[8];
+    byte readBuf[kFrameSize];
 
     byte controllerAddress;
     bool controllerIsPrimary = true;
@@ -97,7 +99,7 @@ class FujiHeatPump {
 
     FujiFrame decodeFrame();
     void encodeFrame(FujiFrame ff, byte* writeBuf);
-    void printFrame(byte buf[8], FujiFrame ff);
+    void printFrame(byte buf[kFrameSize], FujiFrame ff);
 
     QueueHandle_t uart_queue;
     uart_port_t uart_port;


### PR DESCRIPTION
Received this during logging

[10:42:40][I][FujiHeatPump:171]: ring buffer full